### PR TITLE
Config: add `--close-after-days` cli option

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,15 +1,21 @@
 class Configuration
    attr_accessor :repo,
                  :stale_after_days,
+                 :close_after_days,
                  :exempt_label,
                  :dry_run
 
    def initialize
       self.stale_after_days = 30
+      self.close_after_days = 7
    end
 
    def stale_after_seconds
       stale_after_days * 86400
+   end
+
+   def close_after_seconds
+      close_after_days * 86400
    end
 
    ##
@@ -28,13 +34,23 @@ class Configuration
 
          opts.on("--stale-after-days DAYS", OptionParser::DecimalInteger,
                        "Number of days to wait after the last activity",
-                       "on an issue before commenting or closing.") do |v|
+                       "on an issue before commenting. Default: " +
+                       "#{config.stale_after_days}") do |v|
             config.stale_after_days = v
             Log.debug "Setting stale_after_days to #{config.stale_after_days}"
          end
 
+         opts.on("--close-after-days DAYS", OptionParser::DecimalInteger,
+                       "Number of days to wait after commenting",
+                       "on an issue before closing. Default: " +
+                       "#{config.close_after_days}") do |v|
+            config.close_after_days = v
+            Log.debug "Setting close_after_days to #{config.close_after_days}"
+         end
+
          opts.on("--dry-run",
-                 "Don't actually write anything to github, only read") do |v|
+                 "Don't actually write anything to github,",
+                 "only read") do |v|
             config.dry_run = v
             Log.debug "Setting dry-run"
          end

--- a/github.rb
+++ b/github.rb
@@ -48,6 +48,26 @@ git config github.token 'thetoken'"
          raise "remote.origin.url in git config but be a github url"
       end
    end
+
+   ##
+   # Given an array returned by any of the endpoints (Github.issues
+   # for instance) this will iterate over each entry, doing the
+   # pagination as needed until there are no more items or the caller
+   # calls `break`
+   def self.each(batch)
+      response = Github.api.last_response
+      while batch.length > 0
+         batch.each do |item|
+            yield item
+         end
+         if response.rels[:next]
+            response = response.rels[:next].get
+            batch = response.data
+         else
+            return;
+         end
+      end
+   end
 end
 
 class OctokitWrapper

--- a/models/comment.rb
+++ b/models/comment.rb
@@ -14,4 +14,8 @@ class Comment
    def body_contains(str)
       @comment.body && @comment.body.include?(str)
    end
+
+   def date
+      @comment.created_at
+   end
 end

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -13,8 +13,27 @@ class Issue
       comment.body_contains(intro_text)
    end
 
-   def is_old
-      @issue.updated_at < (Time.now - Nagnagnag.config.stale_after_days)
+   ##
+   # Returns true if the last comment was made more than
+   # `--stale-after-days` ago
+   def should_comment
+      last_activity_date < (Time.now - Nagnagnag.config.stale_after_seconds)
+   end
+
+   ##
+   # Returns true if the last comment was made more than
+   # `--close-after-days` ago
+   def should_close
+      last_activity_date < (Time.now - Nagnagnag.config.close_after_seconds)
+   end
+
+   ##
+   # Returns true if there has been no activity on the issue whatsoever
+   # in the last min(close-after-days, stale-after-days) days.
+   def no_recent_activity
+      config = Nagnagnag.config
+      old_after_seconds = [config.close_after_seconds, config.stale_after_seconds].min
+      @issue.updated_at < (Time.now - old_after_seconds)
    end
 
    def is_pull_request
@@ -50,7 +69,7 @@ class Issue
       all = []
       Github.each(issues) do |issue_data|
          issue = Issue.new(repo, issue_data)
-         if issue.is_old
+         if issue.no_recent_activity
             next if issue.is_pull_request
             if issue.is_exempt
                Log.debug "Issue ##{issue.number} is exempt"
@@ -67,14 +86,28 @@ class Issue
       all
    end
 
+   def last_activity_date
+      (last_comment && last_comment.date) || @issue.created_at
+   end
+
    def last_comment
+      @last_comment ||= get_last_comment
+   end
+
+   def get_last_comment
       Log.info "Loading last_comment for issue ##{@issue.number}"
-      comments = Github.api.issue_comments(@repo, @issue.number, {
-         :sort => :created,
-         :direction => :desc,
-         :per_page => 1
-      })
-      comments[0] && Comment.new(comments[0])
+      comments = get_all_comments
+      comments.last && Comment.new(comments.last)
+   end
+
+   def get_all_comments
+      comments = Github.api.issue_comments(@repo, @issue.number)
+
+      all = []
+      Github.each(comments) do |comment|
+         all << comment
+      end
+      all
    end
 
    def close

--- a/nagnagnag.rb
+++ b/nagnagnag.rb
@@ -28,9 +28,11 @@ class Nagnagnag
       Issue.old_issues(Nagnagnag.config.repo).each do |issue|
          Log.debug "Looking at comments on issue ##{issue.number}"
          if issue.last_comment_was_by(me)
-            issue.close
-         else
-            issue.comment_on_issue()
+            if issue.should_close
+               issue.close
+            end
+         elsif issue.should_comment
+            issue.comment_on_issue
          end
       end
    end


### PR DESCRIPTION
So that you can specify more precisely control the timing of stages
that issues go through during the process:
1. waiting (--stale-after-days)
2. Comment on issue
3. waiting  (--close-after-days)
4. Close issue

Also, change the "stale" state to be dependent on the date of the last
comment, not the last edit. Otherwise any edit to any comment will
keep an issue open and uncommented on.

We only consider new comments to be important.
