### PR TITLE
Add some more nags

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,12 +2,14 @@ class Configuration
    attr_accessor :repo,
                  :stale_after_days,
                  :close_after_days,
+                 :urgent_after_days,
                  :exempt_label,
                  :dry_run
 
    def initialize
       self.stale_after_days = 30
       self.close_after_days = 7
+      self.urgent_after_days = 5
    end
 
    def stale_after_seconds
@@ -46,6 +48,14 @@ class Configuration
                        "#{config.close_after_days}") do |v|
             config.close_after_days = v
             Log.debug "Setting close_after_days to #{config.close_after_days}"
+         end
+
+         opts.on("--urgent-after-days DAYS", OptionParser::DecimalInteger,
+                       "Distance from milestone due date after which",
+                       "an issue should get a reminder comment. Default: " +
+                       "#{config.urgent_after_days}") do |v|
+            config.urgent_after_days = v
+            Log.debug "Setting urgent_after_days to #{config.urgent_after_days}"
          end
 
          opts.on("--dry-run",

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -262,6 +262,13 @@ class Issue
       end
    end
 
+   def comment_no_issue_warning
+      Log.info "Commenting no issue warning on issue ##{@issue.number}"
+      if !Nagnagnag.config.dry_run
+         Github.api.add_comment(@repo, @issue.number, no_issue_warning)
+      end
+   end
+
    def comment_score_reminder
       Log.info "Commenting score reminder on issue ##{@issue.number}"
       if !Nagnagnag.config.dry_run
@@ -285,6 +292,17 @@ class Issue
          This issue hasn't seen any activity in #{days} days.
          It will be automatically closed after another #{close_days} days
          unless #{exempt_label_message} there are further comments.
+      COMMENT
+      str.gsub(/\s+/, ' ')
+   end
+
+   protected
+   def no_issue_warning
+      str = <<-COMMENT
+         **#{intro_text}**
+         This pull request is not associated with an issue. Create an issue,
+         label it with a difficulty score, and associate it with this pull
+         request.
       COMMENT
       str.gsub(/\s+/, ' ')
    end

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -62,17 +62,17 @@ class Issue
    ##
    # Returns array of Issue objects
    ##
-   def self.get_issues(repo)
-      Log.info "Loading all issues"
-      Github.api.issues(repo, {
-         # all = don't limit to issues assigned to me
-         # :filter     => :all,
+   def self.get_issues(repo, options = {})
+      options = {
          :state      => :open,
          :sort       => :updated,
          :direction  => :asc,
          :assignee   => "*",
          :per_page   => 100
-      })
+      }.merge(options)
+
+      Log.info "Loading all issues"
+      Github.api.issues(repo, options)
    end
 
    def self.unscored_issues(issues, repo)

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -49,6 +49,15 @@ class Issue
       @issue.labels.any? { |label| label.name == 's-Under Review' }
    end
 
+   def has_issue
+      keywords = ["close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved", "description", "connect to", "connects to", "connected to", "connects"]
+
+      pattern = '\b' + '(' + keywords.join("|") + ')' + '\s+' + '#[0-9]+' + '\b'
+      re = Regexp.new(pattern, Regexp::IGNORECASE)
+
+      !(re =~ description).nil?
+   end
+
    def is_pull_request
       @issue.pull_request
    end
@@ -167,6 +176,23 @@ class Issue
 
          if issue.description.empty?
             all << issue
+         end
+      end
+      all
+   end
+
+   ##
+   # Returns array of Issue objects which are pull requests without an
+   # associated issue
+   ##
+   def self.disconnected_pulls(pulls, repo)
+      Log.info "Selecting pulls without an pull"
+      all = []
+      Github.each(pulls) do |pull_data|
+         pull = Issue.new(repo, pull_data)
+
+         unless pull.has_issue
+            all << pull
          end
       end
       all

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -79,6 +79,19 @@ class Issue
       Github.api.issues(repo, options)
    end
 
+   def self.get_pulls(repo, options = {})
+      options = {
+         :state      => :open,
+         :sort       => :updated,
+         :direction  => :asc,
+         :assignee   => "*",
+         :per_page   => 100
+      }.merge(options)
+
+      Log.info "Loading all pulls"
+      Github.api.pull_requests(repo, options)
+   end
+
    def self.unscored_issues(issues, repo)
       Log.info "Selecting unscored issues"
       all = []

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -121,6 +121,23 @@ class Issue
       all
    end
 
+   ##
+   # Returns array of Issue objects on a milestone with a due date
+   ##
+   def self.due_issues(issues, repo)
+      Log.info "Selecting issues with deadlines"
+      all = []
+      Github.each(issues) do |issue_data|
+         issue = Issue.new(repo, issue_data)
+         next if issue.is_pull_request
+
+         unless issue.due_on.nil?
+            all << issue
+         end
+      end
+      all
+   end
+
    def last_activity_date
       (last_comment && last_comment.date) || @issue.created_at
    end
@@ -143,6 +160,11 @@ class Issue
          all << comment
       end
       all
+   end
+
+   def due_on
+      time = @issue[:milestone][:due_on]
+      time.nil? ? nil : time.to_date
    end
 
    def close

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -142,12 +142,38 @@ class Issue
       all
    end
 
+   ##
+   # Returns array of Issue objects with an empty description
+   ##
+   def self.empty_issues(issues, repo)
+      Log.info "Selecting issues with deadlines"
+      all = []
+      Github.each(issues) do |issue_data|
+         issue = Issue.new(repo, issue_data)
+         next if issue.is_pull_request
+
+         if issue.description.empty?
+            all << issue
+         end
+      end
+      all
+   end
+
    def last_activity_date
       (last_comment && last_comment.date) || @issue.created_at
    end
 
    def last_comment
       @last_comment ||= get_last_comment
+   end
+
+   def description
+      @description ||= get_description
+   end
+
+   def get_description
+      Log.info "Loading description for issue ##{@issue.number}"
+      @issue[:body]
    end
 
    def get_last_comment

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -62,7 +62,7 @@ class Issue
          :state      => :open,
          :sort       => :updated,
          :direction  => :asc,
-         :asignee    => "*",
+         :assignee   => "*",
          :per_page   => 100
       })
 

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -36,6 +36,15 @@ class Issue
       @issue.updated_at < (Time.now - old_after_seconds)
    end
 
+   ##
+   # Returns true if an issue has a numeric label
+   def has_score
+      @issue.labels.any? do |label|
+         val = Integer(label.name) rescue nil
+         !!val
+      end
+   end
+
    def is_pull_request
       @issue.pull_request
    end
@@ -51,12 +60,11 @@ class Issue
    end
 
    ##
-   # Returns array of Issue objects for all issues that haven't been updated
-   # in Nagnagnag.config.stale_after_days
+   # Returns array of Issue objects
    ##
-   def self.old_issues(repo)
-      Log.info "Loading issues and selecting only the stale ones"
-      issues = Github.api.issues(repo, {
+   def self.get_issues(repo)
+      Log.info "Loading all issues"
+      Github.api.issues(repo, {
          # all = don't limit to issues assigned to me
          # :filter     => :all,
          :state      => :open,
@@ -65,7 +73,34 @@ class Issue
          :assignee   => "*",
          :per_page   => 100
       })
+   end
 
+   def self.unscored_issues(issues, repo)
+      Log.info "Selecting unscored issues"
+      all = []
+      Github.each(issues) do |issue_data|
+         issue = Issue.new(repo, issue_data)
+         next if issue.is_pull_request
+
+         unless issue.has_score
+            if issue.is_exempt
+               Log.debug "Issue ##{issue.number} is exempt"
+            else
+               all << issue
+               Log.debug "Issue ##{issue.number} does not have a score"
+            end
+         end
+      end
+      Log.info "Found #{all.length} unscored issues"
+      all
+   end
+
+   ##
+   # Returns array of Issue objects for all issues that haven't been updated
+   # in Nagnagnag.config.stale_after_days
+   ##
+   def self.old_issues(issues, repo)
+      Log.info "Selecting stale issues"
       all = []
       Github.each(issues) do |issue_data|
          issue = Issue.new(repo, issue_data)
@@ -117,10 +152,17 @@ class Issue
       end
    end
 
-   def comment_on_issue
-      Log.info "Commenting on issue ##{@issue.number}"
+   def comment_stale_warning
+      Log.info "Commenting stale warning on issue ##{@issue.number}"
       if !Nagnagnag.config.dry_run
          Github.api.add_comment(@repo, @issue.number, warning_message)
+      end
+   end
+
+   def comment_score_reminder
+      Log.info "Commenting score reminder on issue ##{@issue.number}"
+      if !Nagnagnag.config.dry_run
+         Github.api.add_comment(@repo, @issue.number, score_reminder)
       end
    end
 
@@ -133,6 +175,16 @@ class Issue
          This issue hasn't seen any activity in #{days} days.
          It will be automatically closed after another #{close_days} days
          unless #{exempt_label_message} there are further comments.
+      COMMENT
+      str.gsub(/\s+/, ' ')
+   end
+
+   protected
+   def score_reminder
+      str = <<-COMMENT
+         **#{intro_text}**
+         This issue does not have a difficulty score. Please add a label
+         estimating the difficulty of this project.
       COMMENT
       str.gsub(/\s+/, ' ')
    end

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -216,6 +216,13 @@ class Issue
       end
    end
 
+   def comment_empty_warning
+      Log.info "Commenting empty warning on issue ##{@issue.number}"
+      if !Nagnagnag.config.dry_run
+         Github.api.add_comment(@repo, @issue.number, empty_message)
+      end
+   end
+
    def comment_score_reminder
       Log.info "Commenting score reminder on issue ##{@issue.number}"
       if !Nagnagnag.config.dry_run
@@ -239,6 +246,15 @@ class Issue
          This issue hasn't seen any activity in #{days} days.
          It will be automatically closed after another #{close_days} days
          unless #{exempt_label_message} there are further comments.
+      COMMENT
+      str.gsub(/\s+/, ' ')
+   end
+
+   protected
+   def empty_message
+      str = <<-COMMENT
+         **#{intro_text}**
+         Please add a description to this issue.
       COMMENT
       str.gsub(/\s+/, ' ')
    end

--- a/nagnagnag.rb
+++ b/nagnagnag.rb
@@ -25,15 +25,25 @@ class Nagnagnag
 
    def nagnagnag
       me = Github::config("github.user")
-      Issue.old_issues(Nagnagnag.config.repo).each do |issue|
+      issues = Issue.get_issues(Nagnagnag.config.repo)
+
+      Issue.old_issues(issues, Nagnagnag.config.repo).each do |issue|
          Log.debug "Looking at comments on issue ##{issue.number}"
          if issue.last_comment_was_by(me)
             if issue.should_close
                issue.close
+               Log.debug "Should close #{issue.number}"
             end
          elsif issue.should_comment
-            issue.comment_on_issue
+            issue.comment_stale_warning
+            Log.debug "Should comment #{issue.number}"
          end
+      end
+
+      Issue.unscored_issues(issues, Nagnagnag.config.repo).each do |issue|
+         Log.debug "Looking at scores on issue ##{issue.number}"
+         issue.comment_score_reminder
+         Log.debug "Should comment #{issue.number}"
       end
    end
 end

--- a/nagnagnag.rb
+++ b/nagnagnag.rb
@@ -25,9 +25,9 @@ class Nagnagnag
 
    def nagnagnag
       me = Github::config("github.user")
-      issues = Issue.get_issues(Nagnagnag.config.repo)
+      all_issues = Issue.get_issues(Nagnagnag.config.repo)
 
-      Issue.old_issues(issues, Nagnagnag.config.repo).each do |issue|
+      Issue.old_issues(all_issues, Nagnagnag.config.repo).each do |issue|
          Log.debug "Looking at comments on issue ##{issue.number}"
          if issue.last_comment_was_by(me)
             if issue.should_close
@@ -40,13 +40,18 @@ class Nagnagnag
          end
       end
 
-      Issue.unscored_issues(issues, Nagnagnag.config.repo).each do |issue|
+      Issue.unscored_issues(all_issues, Nagnagnag.config.repo).each do |issue|
          Log.debug "Looking at scores on issue ##{issue.number}"
          issue.comment_score_reminder
          Log.debug "Should comment #{issue.number}"
       end
 
       milestone_issues = Issue.get_issues(Nagnagnag.config.repo, {:milestone => '*'})
+      Issue.due_issues(milestone_issues, Nagnagnag.config.repo).each do |issue|
+         if issue.due_soon && !issue.has_pull
+            issue.comment_milestone_reminder
+         end
+      end
    end
 end
 

--- a/nagnagnag.rb
+++ b/nagnagnag.rb
@@ -60,6 +60,12 @@ class Nagnagnag
             issue.comment_milestone_reminder
          end
       end
+
+      all_pulls = Issue.get_pulls(Nagnagnag.config.repo)
+      Issue.disconnected_pulls(all_pulls, Nagnagnag.config.repo).each do |pull|
+         Log.debug "Looking for related issue on pull ##{pull.number}"
+         issue.comment_no_issue_warning
+      end
    end
 end
 

--- a/nagnagnag.rb
+++ b/nagnagnag.rb
@@ -45,6 +45,8 @@ class Nagnagnag
          issue.comment_score_reminder
          Log.debug "Should comment #{issue.number}"
       end
+
+      milestone_issues = Issue.get_issues(Nagnagnag.config.repo, {:milestone => '*'})
    end
 end
 

--- a/nagnagnag.rb
+++ b/nagnagnag.rb
@@ -41,13 +41,14 @@ class Nagnagnag
       end
 
       Issue.unscored_issues(all_issues, Nagnagnag.config.repo).each do |issue|
-         Log.debug "Looking at scores on issue ##{issue.number}"
+         Log.debug "Looking for score on issue ##{issue.number}"
          issue.comment_score_reminder
          Log.debug "Should comment #{issue.number}"
       end
 
       milestone_issues = Issue.get_issues(Nagnagnag.config.repo, {:milestone => '*'})
       Issue.due_issues(milestone_issues, Nagnagnag.config.repo).each do |issue|
+         Log.debug "Looking at milestone due date on issue ##{issue.number}"
          if issue.due_soon && !issue.has_pull
             issue.comment_milestone_reminder
          end

--- a/nagnagnag.rb
+++ b/nagnagnag.rb
@@ -46,6 +46,13 @@ class Nagnagnag
          Log.debug "Should comment #{issue.number}"
       end
 
+      Issue.empty_issues(all_issues, Nagnagnag.config.repo).each do |issue|
+         Log.debug "Looking at description of issue ##{issue.number}"
+         if !issue.has_pull
+            issue.comment_empty_warning
+         end
+      end
+
       milestone_issues = Issue.get_issues(Nagnagnag.config.repo, {:milestone => '*'})
       Issue.due_issues(milestone_issues, Nagnagnag.config.repo).each do |issue|
          Log.debug "Looking at milestone due date on issue ##{issue.number}"


### PR DESCRIPTION
This adds a few features to nagnagnag:
- Nag non-exempt issues (a good exemption might be the `rfc` label) that don't have a numeric label (i.e. `"1"`, `"3"`, `"5"`, etc.)
- Nag issues that are on a milestone due within N days (5 days by default) which don't yet have a pull request associated with them.
- Nag issues with no description which don't yet have a pull request associated with them.
- Nag pulls with no issue associated with them.

CC @kwiens @danielbeardsley

Closes iFixit/ifixit_scripts#75
