### PR TITLE
Closing issues: optionally add label when closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ A specific label `[--exempt-label]` can exempt issues from auto-closing.
                                           only read
              --exempt-label LABEL         Name of issue label that will prevent issues
                                           from being examined or modified by this bot.
+             --closed-label LABEL         Name of issue label that be added
+                                          when issues are closed.
          -h, --help                       Show this message

--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,7 @@ class Configuration
                  :stale_after_days,
                  :close_after_days,
                  :exempt_label,
+                 :closed_label,
                  :dry_run
 
    def initialize
@@ -60,6 +61,13 @@ class Configuration
                        "from being examined or modified by this bot.") do |v|
             config.exempt_label = v
             Log.debug "Exempting issues with label #{config.exempt_label}"
+         end
+
+         opts.on("--closed-label LABEL", String,
+                       "Name of issue label that be added",
+                       "when issues are closed.") do |v|
+            config.closed_label = v
+            Log.debug "Adding label #{config.closed_label} to issues that get closed"
          end
 
          opts.on_tail("-h", "--help", "Show this message") do

--- a/models/issue.rb
+++ b/models/issue.rb
@@ -114,6 +114,11 @@ class Issue
       Log.info "Closing issue ##{@issue.number}"
       if !Nagnagnag.config.dry_run
          Github.api.close_issue(@repo, @issue.number)
+         if Nagnagnag.config.closed_label
+            label = Nagnagnag.config.closed_label
+            Log.info "Adding label #{label} to issue ##{@issue.number}"
+            Github.api.add_labels_to_an_issue(@repo, @issue.number, [label])
+         end
       end
    end
 


### PR DESCRIPTION
So that uses of the tool can differentiate issues that were closed
because they were finished vs those closed by nagnagnag.